### PR TITLE
Fix main 'vg-videogular-overlay-play' in bower

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "videogular-overlay-play",
   "version": "1.0.0",
-  "main": "./overlay-play.js",
+  "main": "./vg-overlay-play.js",
   "dependencies": {
     "videogular": "latest"
   }


### PR DESCRIPTION
The Wiredep can not add files , because of the wrong file name in the mian bower.json